### PR TITLE
chore: api key 파일 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,5 @@ fabric.properties
 !/gradle/wrapper/gradle-wrapper.jar
 
 # End of https://www.toptal.com/developers/gitignore/api/androidstudio,kotlin
+
+app/src/main/res/values/api_key.xml

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,7 +13,7 @@
     <string name="invalid_password">Password must be >5 characters</string>
     <string name="login_failed">"Login failed"</string>
     <string name="title_activity_settings">Settings</string>
-    <string name="kakao_app_key">725142975edfd7a2368f7dc2bf8eb89c</string>
+
 
     <!-- Preference Titles -->
     <string name="messages_header">Messages</string>


### PR DESCRIPTION
api key 파일은 notion 클라이언트 전달사항에 있음