### PR TITLE
fix: 카톡 프사 없을때 로그인시 팅기는 증상 해결

### DIFF
--- a/app/src/main/java/com/ppcomp/knu/activity/LoginActivity.kt
+++ b/app/src/main/java/com/ppcomp/knu/activity/LoginActivity.kt
@@ -33,9 +33,9 @@ import kotlinx.coroutines.runBlocking
 
 class LoginActivity : AppCompatActivity() {
     private var callback: SessionCallback = SessionCallback() //카카오에서 제공하는 콜백함수
-    private lateinit var kakaoId: String
-    private lateinit var kakaoNickname: String
-    private lateinit var kakakoThumbnail: String
+    private var kakaoId: String? = null
+    private var kakaoNickname: String? = null
+    private var kakakoThumbnail: String? = null
     private lateinit var searchIcon: ImageView
     private lateinit var myToast: Toast
     private var backWait: Long = 0


### PR DESCRIPTION
카톡 프사 url을 저장하는 변수가 non-null로 선언되어 있었음.